### PR TITLE
Fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git+https://github.com/Aksem/libavoid-js.git"
   },
   "author": "Vladyslav Hnatiuk",
-  "license": "MIT",
+  "license": "LGPL-2.1-or-later",
   "bugs": {
     "url": "https://github.com/Aksem/libavoid-js/issues"
   },


### PR DESCRIPTION
The package is currently published with MIT license on NPM and not [LGPL 2.1 or later](https://github.com/mjwybrow/adaptagrams).
