### PR TITLE
Fix typings for ConnRef

### DIFF
--- a/typings/libavoid.d.ts
+++ b/typings/libavoid.d.ts
@@ -32,13 +32,16 @@ declare interface ConnEnd {
 }
 
 declare interface ConnRef {
+  new (router: Router): ConnRef;
   new (router: Router, srcConnEnd: ConnEnd, dstConnEnd: ConnEnd): ConnRef;
+
+  g: number;
 
   displayRoute(): PolyLine;
   setSourceEndpoint(srcPoint: ConnEnd): void;
   setDestEndpoint(dstPoint: ConnEnd): void;
   setRoutingType(type: number): void;
-  setCallback(callback: (connRef: ConnRef) => void, connRef: ConnRef): void;
+  setCallback(callback: (connRefPtr: number) => void, connRef: ConnRef): void;
 
   setHateCrossings(value: boolean): void;
   doesHateCrossings(): boolean;

--- a/typings/libavoid.d.ts
+++ b/typings/libavoid.d.ts
@@ -35,12 +35,13 @@ declare interface ConnRef {
   new (router: Router): ConnRef;
   new (router: Router, srcConnEnd: ConnEnd, dstConnEnd: ConnEnd): ConnRef;
 
-  g: number;
-
   displayRoute(): PolyLine;
   setSourceEndpoint(srcPoint: ConnEnd): void;
   setDestEndpoint(dstPoint: ConnEnd): void;
   setRoutingType(type: number): void;
+  // connRefPtr is raw pointer to the object, to get ConnRef object use:
+  // `const connRef = Avoid.wrapPointer(connRefPtr, Avoid.ConnRef)`
+  // more details: https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html#pointers-and-comparisons
   setCallback(callback: (connRefPtr: number) => void, connRef: ConnRef): void;
 
   setHateCrossings(value: boolean): void;


### PR DESCRIPTION
Implements the following TypeScript fixes for the `ConnRef` class:
- Documents the simpler constructor of ConnRef ([documented here](https://www.adaptagrams.org/documentation/classAvoid_1_1ConnRef.html#a2e08b9bb04ccf383700487932f13c980))
- Documents the `g` property of ConnRef (to enable referencing the ConnRef instance)
- Fixes the argument of the `callback` of `setCallback()` method - it is only the `g` pointer of a ConnRef, not a ConnRef instance ([documented here](http://www.adaptagrams.org/documentation/classAvoid_1_1ConnRef.html#a9d1a26643759adbb84f350285ce42d64))