### PR TITLE
Add typings for Avoid.getPointer and wrapPointer methods

### DIFF
--- a/typings/libavoid.d.ts
+++ b/typings/libavoid.d.ts
@@ -109,6 +109,8 @@ export interface Avoid {
   JunctionRef: JunctionRef;
 
   destroy(obj: any): void;
+  getPointer(obj: any): number;
+  wrapPointer<T>(ptr: number, Class: T): T;
 }
 
 export namespace AvoidLib {


### PR DESCRIPTION
Building on from https://github.com/Aksem/libavoid-js/pull/15, implements the following TypeScript fixes for the `Avoid` interface:
- Documents the `Avoid.getPointer()` method ([from WebIDL bindings](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html#pointers-and-comparisons))
- Documents the `Avoid.wrapPointer()` method ([from WebIDL bindings](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html#pointers-and-comparisons))