### PR TITLE
Add JunctionRef bindings for hyperedge routing

### DIFF
--- a/embind/bindings.cpp
+++ b/embind/bindings.cpp
@@ -25,6 +25,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("deleteShape", &Avoid::Router::deleteShape, allow_raw_pointers())
     .function("moveJunction_point", select_overload<void(Avoid::JunctionRef*, const Avoid::Point&)>(&Avoid::Router::moveJunction), allow_raw_pointers())
     .function("moveJunction_delta", select_overload<void(Avoid::JunctionRef*, double, double)>(&Avoid::Router::moveJunction), allow_raw_pointers())
+    .function("deleteJunction", &Avoid::Router::deleteJunction, allow_raw_pointers())
     .function("setRoutingParameter", &Avoid::Router::setRoutingParameter)
     .function("setRoutingOption", &Avoid::Router::setRoutingOption);
 
@@ -97,6 +98,13 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("polygon", &Avoid::ShapeRef::polygon)
     .function("position", &Avoid::ShapeRef::position)
     .function("setNewPoly", &Avoid::ShapeRef::setNewPoly);
+
+    class_<Avoid::JunctionRef, emscripten::base<Avoid::Obstacle>>("JunctionRef")
+    .constructor<Avoid::Router*, Avoid::Point, unsigned long>()
+    .function("position", &Avoid::JunctionRef::position)
+    .function("setPositionFixed", &Avoid::JunctionRef::setPositionFixed)
+    .function("positionFixed", &Avoid::JunctionRef::positionFixed)
+    .function("recommendedPosition", &Avoid::JunctionRef::recommendedPosition);
 
     enum_<Avoid::ConnType>("ConnType")
     .value("ConnType_None", Avoid::ConnType_None)

--- a/examples/node/junction-example.mjs
+++ b/examples/node/junction-example.mjs
@@ -1,0 +1,72 @@
+import { AvoidLib } from '../dist/index-node.mjs';
+
+function printRoutes(conns) {
+  for (const [name, conn] of conns) {
+    const route = conn.displayRoute();
+    const points = [];
+    for (let i = 0; i < route.size(); i++) {
+      points.push(`(${route.at(i).x}, ${route.at(i).y})`);
+    }
+    console.log(`  ${name} route:`, points.join(' -> '));
+  }
+}
+
+function createScenario(Avoid, { fixedJunction = false } = {}) {
+  const router = new Avoid.Router(Avoid.RouterFlag.OrthogonalRouting.value);
+  router.setRoutingParameter(Avoid.RoutingParameter.segmentPenalty.value, 50);
+  router.setRoutingParameter(Avoid.RoutingParameter.idealNudgingDistance.value, 25);
+
+  const shape1 = new Avoid.ShapeRef(router,
+    new Avoid.Rectangle(new Avoid.Point(100, 100), new Avoid.Point(200, 200)), 1);
+  const shape2 = new Avoid.ShapeRef(router,
+    new Avoid.Rectangle(new Avoid.Point(400, 100), new Avoid.Point(500, 200)), 2);
+  const shape3 = new Avoid.ShapeRef(router,
+    new Avoid.Rectangle(new Avoid.Point(400, 300), new Avoid.Point(500, 400)), 3);
+
+  const junction = new Avoid.JunctionRef(router, new Avoid.Point(300, 200), 100);
+  if (fixedJunction) {
+    junction.setPositionFixed(true);
+  }
+
+  const conn1 = new Avoid.ConnRef(router,
+    new Avoid.ConnEnd(new Avoid.Point(150, 150)),
+    Avoid.ConnEnd.createConnEndFromJunctionRef(junction), 201);
+  const conn2 = new Avoid.ConnRef(router,
+    Avoid.ConnEnd.createConnEndFromJunctionRef(junction),
+    new Avoid.ConnEnd(new Avoid.Point(450, 150)), 202);
+  const conn3 = new Avoid.ConnRef(router,
+    Avoid.ConnEnd.createConnEndFromJunctionRef(junction),
+    new Avoid.ConnEnd(new Avoid.Point(450, 350)), 203);
+
+  router.processTransaction();
+
+  const pos = junction.position();
+  const rec = junction.recommendedPosition();
+  console.log(`  Junction position: (${pos.x}, ${pos.y})`);
+  console.log(`  Recommended position: (${rec.x}, ${rec.y})`);
+  console.log(`  Position fixed: ${junction.positionFixed()}`);
+  printRoutes([['conn1', conn1], ['conn2', conn2], ['conn3', conn3]]);
+
+  // Cleanup
+  router.deleteConnector(conn1);
+  router.deleteConnector(conn2);
+  router.deleteConnector(conn3);
+  router.deleteJunction(junction);
+  router.processTransaction();
+  router.delete();
+}
+
+async function main() {
+  await AvoidLib.load();
+  const Avoid = AvoidLib.getInstance();
+
+  console.log("=== 1. Router-optimized junction (default) ===");
+  createScenario(Avoid);
+
+  console.log("\n=== 2. Fixed junction at (300, 200) ===");
+  createScenario(Avoid, { fixedJunction: true });
+
+  console.log("\nDone!");
+}
+
+main();

--- a/typings/libavoid.d.ts
+++ b/typings/libavoid.d.ts
@@ -38,6 +38,7 @@ declare interface Router {
   moveShape_poly(shape: ShapeRef, newPolygon: Polygon);
   moveShape_delta(shape: ShapeRef, xDiff: number, yDiff: number);
   deleteShape(shape: ShapeRef);
+  deleteJunction(junction: JunctionRef): void;
   setRoutingParameter(parameter: RoutingParameter, value: number): void;
   setRoutingOption(option: RoutingOption, value: boolean): void;
 


### PR DESCRIPTION
Implements #35.

## Summary
  - Add `JunctionRef` embind bindings: constructor, `position()`, `setPositionFixed()`, `positionFixed()`, `recommendedPosition()`
  - Add `Router.deleteJunction()` binding for cleanup
  - Update TypeScript typings with `deleteJunction`
  - Add node example demonstrating junction-based hyperedge routing (router-optimized vs fixed position)

## Note
Unfortunately, `shapeBufferDistance` doesn't seem to have any effect on junction placement. The optimizer just keeps pulling it toward the minimum-length _Steiner point_ no matter what.
For now, `setPositionFixed(true)` might be the only way to keep the junction where the developer wants it, though I'm not 100% sure there isn't something else I'm missing.