### PR TITLE
fix: add browser export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "browser": "./dist/index.js",
       "node": "./dist/index-node.mjs",
       "types": "./dist/libavoid.d.ts",
       "default": "./dist/index.js"


### PR DESCRIPTION
Bundlers and test runners such as Vite, Webpack, and Vitest running in a browser-like environment (e.g. jsdom) resolve the node export condition because they run on Node.js under the hood. This causes them to load index-node.mjs, which uses createRequire(an API unavailable in browser environments) instead of the intended browser bundle.

Adding a browser export condition that explicitly points to index.js allows these tools to select the correct bundle when targeting a browser environment, without affecting existing Node.js consumers.